### PR TITLE
Remove unused `Locales` extender

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -17,5 +17,5 @@ return [
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js')
         ->css(__DIR__.'/less/admin.less'),
-    new Extend\Locales(__DIR__.'/locale'),
+    //new Extend\Locales(__DIR__.'/locale'),
 ];


### PR DESCRIPTION
There are no translations in `locale/en.yml`.